### PR TITLE
disconnected isn't a valid state (and spams HA log)

### DIFF
--- a/AnovaMaster/AnovaMaster.py
+++ b/AnovaMaster/AnovaMaster.py
@@ -17,7 +17,7 @@ from .StatusException import StatusException
 
 import bluepy
 
-valid_states = { "disconnected",
+valid_states = { "auto",
                  "off",
                  "heat"
 }


### PR DESCRIPTION

The best I could think of was to change it to "auto", kinda implying that it will "auto-connect" when it's available.

Valid states:
https://www.home-assistant.io/integrations/climate.mqtt/#modes


> 2020-10-03 10:00:55 ERROR (MainThread) [homeassistant.components.mqtt.climate] Invalid modes mode: disconnected
> 2020-10-03 10:01:42 ERROR (MainThread) [homeassistant.components.mqtt.climate] Invalid modes mode: disconnected
> 2020-10-03 10:02:29 ERROR (MainThread) [homeassistant.components.mqtt.climate] Invalid modes mode: disconnected
> 2020-10-03 10:03:16 ERROR (MainThread) [homeassistant.components.mqtt.climate] Invalid modes mode: disconnected
> 2020-10-03 10:04:03 ERROR (MainThread) [homeassistant.components.mqtt.climate] Invalid modes mode: disconnected
> 2020-10-03 10:04:50 ERROR (MainThread) [homeassistant.components.mqtt.climate] Invalid modes mode: disconnected
> 